### PR TITLE
Github action to build AppImage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage-action@master
         env:
-          UPDATE_INFO: gh-releases-zsync|agriffit79|melodeon|latest|Melodeon*x86_64.AppImage.zsync
+          UPDATE_INFO: gh-releases-zsync|CDrummond|melodeon|latest|Melodeon*x86_64.AppImage.zsync
         with:
           recipe: AppImageBuilder.yml
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools
+          git submodule update --init --recursive
       - name: configure
         run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
       - name: build

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -22,36 +22,14 @@ jobs:
         run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
       - name: build
         run: make -j`nproc` install DESTDIR=AppDir && mv AppDir/usr/share/applications/melodeon.desktop AppDir/usr/share/applications/io.github.cdrummond.melodeon.desktop
+      - name: Populate app version
+        run: |
+          sed s"/@@VERSION@@/$(xmllint linux/melodeon.metainfo.xml --xpath '/component/releases/release[1]/@version' | cut -d '"' -f 2)/" AppImageBuilder.yml.in > AppImageBuilder.yml
+          grep version AppImageBuilder.yml
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage-action@master
         env:
           UPDATE_INFO: gh-releases-zsync|agriffit79|melodeon|latest|Melodeon*x86_64.AppImage.zsync
-        with:
-          recipe: AppImageBuilder.yml
-      - uses: actions/upload-artifact@v4
-        with:
-          name: AppImage
-          path: './*.AppImage*'
-
-  build-appimage-arm64:
-
-    runs-on: ubuntu-22.04-arm
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools squashfs-tools
-          git submodule update --init --recursive
-      - name: configure
-        run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
-      - name: build
-        run: make -j`nproc` install DESTDIR=AppDir && mv AppDir/usr/share/applications/melodeon.desktop AppDir/usr/share/applications/io.github.cdrummond.melodeon.desktop
-      - name: Build AppImage
-        uses: AppImageCrafters/build-appimage-action@master
-        env:
-          UPDATE_INFO: gh-releases-zsync|agriffit79|melodeon|latest|Melodeon*aarch64.AppImage.zsync
         with:
           recipe: AppImageBuilder.yml
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools quashfs-tools
+          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools squashfs-tools
           git submodule update --init --recursive
       - name: configure
         run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: configure
         run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
       - name: build
-        run: make -j`nproc`  install DESTDIR=AppDir
+        run: make -j`nproc` install DESTDIR=AppDir && mv AppDir/share/applications/melodeon.desktop AppDir/share/applications/io.github.cdrummond.melodeon.desktop
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage-action@master
         env:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -27,7 +27,7 @@ jobs:
           UPDATE_INFO: gh-releases-zsync|agriffit79|melodeon|latest|Melodeon*x86_64.AppImage.zsync
         with:
           recipe: AppImageBuilder.yml
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: AppImage
           path: './*.AppImage*'

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools
+          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools quashfs-tools
           git submodule update --init --recursive
       - name: configure
         run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,33 @@
+name: C/C++ AppImage
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-appimage:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools
+      - name: configure
+        run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+      - name: build
+        run: make -j`nproc`  install DESTDIR=AppDir
+      - name: Build AppImage
+        uses: AppImageCrafters/build-appimage-action@master
+        env:
+          UPDATE_INFO: gh-releases-zsync|agriffit79|melodeon|latest|Melodeon*x86_64.AppImage.zsync
+        with:
+          recipe: AppImageBuilder.yml
+      - uses: actions/upload-artifact@v2
+        with:
+          name: AppImage
+          path: './*.AppImage*'

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build-appimage:
+  build-appimage-x86:
 
     runs-on: ubuntu-22.04
 
@@ -26,6 +26,32 @@ jobs:
         uses: AppImageCrafters/build-appimage-action@master
         env:
           UPDATE_INFO: gh-releases-zsync|agriffit79|melodeon|latest|Melodeon*x86_64.AppImage.zsync
+        with:
+          recipe: AppImageBuilder.yml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: AppImage
+          path: './*.AppImage*'
+
+  build-appimage-arm64:
+
+    runs-on: ubuntu-22.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools squashfs-tools
+          git submodule update --init --recursive
+      - name: configure
+        run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+      - name: build
+        run: make -j`nproc` install DESTDIR=AppDir && mv AppDir/usr/share/applications/melodeon.desktop AppDir/usr/share/applications/io.github.cdrummond.melodeon.desktop
+      - name: Build AppImage
+        uses: AppImageCrafters/build-appimage-action@master
+        env:
+          UPDATE_INFO: gh-releases-zsync|agriffit79|melodeon|latest|Melodeon*aarch64.AppImage.zsync
         with:
           recipe: AppImageBuilder.yml
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: configure
         run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
       - name: build
-        run: make -j`nproc` install DESTDIR=AppDir && mv AppDir/share/applications/melodeon.desktop AppDir/share/applications/io.github.cdrummond.melodeon.desktop
+        run: make -j`nproc` install DESTDIR=AppDir && mv AppDir/usr/share/applications/melodeon.desktop AppDir/usr/share/applications/io.github.cdrummond.melodeon.desktop
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage-action@master
         env:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools squashfs-tools
+          sudo apt-get install -y cmake g++ qt6-base-dev qt6-webengine-dev libgl1-mesa-dev libxkbcommon-dev libqt6svg6-dev libvulkan-dev qt6-webengine-dev-tools squashfs-tools libxml2-utils
           git submodule update --init --recursive
       - name: configure
         run: cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -2,7 +2,6 @@
 version: 1
 script:
   - which mksquashfs || apt install squashfs-tools
-  - mv AppDir/share/applications/melodeon.desktop AppDir/share/applications/io.github.cdrummond.melodeon.desktop
 AppDir:
   path: ./AppDir
   app_info:

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -35,6 +35,7 @@ AppDir:
 #    - qt6-base-dev
     - libqt6webenginecore6-bin
     - libxkbcommon-x11-0
+    - qt6-qpa-plugins
 #    - libqt6webenginecore6
 #    - libxkbcommon0
 #    - libxcb-cursor0

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -29,6 +29,7 @@ AppDir:
     - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security multiverse
     include:
     - libc6:amd64
+    - libqt6svg6
 #    - libqt6webenginecore6-bin
 #    - libqt6webenginewidgets6
 #    - libqt6webenginecore6

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -30,8 +30,8 @@ AppDir:
     include:
     - libc6:amd64
     - libqt6svg6
+    - libqt6webenginewidgets6
 #    - libqt6webenginecore6-bin
-#    - libqt6webenginewidgets6
 #    - libqt6webenginecore6
 #    - libxkbcommon0
 #    - libxcb-cursor0

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -33,7 +33,7 @@ AppDir:
     - libqt6webenginewidgets6
     - libxcb-xkb1
     - qt6-base-dev
-#    - libqt6webenginecore6-bin
+    - libqt6webenginecore6-bin
 #    - libqt6webenginecore6
 #    - libxkbcommon0
 #    - libxcb-cursor0

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -32,15 +32,14 @@ AppDir:
     - libqt6svg6
     - libqt6webenginewidgets6
     - libxcb-xkb1
+    - qt6-base-dev
 #    - libqt6webenginecore6-bin
 #    - libqt6webenginecore6
 #    - libxkbcommon0
 #    - libxcb-cursor0
-#    - qt6-base-dev
 #    - qt6-webengine-dev
 #    - libgl1-mesa-dev
 #    - libxkbcommon-dev
-#    - libqt6svg6-dev ##
 #    - libvulkan-dev
 #    - qt6-webengine-dev-tools
   files:

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -32,8 +32,9 @@ AppDir:
     - libqt6svg6
     - libqt6webenginewidgets6
     - libxcb-xkb1
-    - qt6-base-dev
+#    - qt6-base-dev
     - libqt6webenginecore6-bin
+    - libxkbcommon-x11-0
 #    - libqt6webenginecore6
 #    - libxkbcommon0
 #    - libxcb-cursor0

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -31,7 +31,7 @@ AppDir:
     - libc6:amd64
     - libqt6svg6
     - libqt6webenginewidgets6
-    - xkb-data
+    - libxcb-xkb
 #    - libqt6webenginecore6-bin
 #    - libqt6webenginecore6
 #    - libxkbcommon0

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -31,7 +31,7 @@ AppDir:
     - libc6:amd64
     - libqt6svg6
     - libqt6webenginewidgets6
-    - libxcb-xkb
+    - libxcb-xkb1
 #    - libqt6webenginecore6-bin
 #    - libqt6webenginecore6
 #    - libxkbcommon0

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -2,13 +2,14 @@
 version: 1
 script:
   - which mksquashfs || apt install squashfs-tools
+  - mv AppDir/share/applications/melodeon.desktop AppDir/share/applications/io.github.cdrummond.melodeon.desktop
 AppDir:
   path: ./AppDir
   app_info:
     id: io.github.cdrummond.melodeon
     name: Melodeon
     icon: melodeon
-    version: 0.4.5
+    version: 0.4.6
     exec: usr/bin/melodeon
     exec_args: $@
   apt:
@@ -32,18 +33,9 @@ AppDir:
     - libqt6svg6
     - libqt6webenginewidgets6
     - libxcb-xkb1
-#    - qt6-base-dev
     - libqt6webenginecore6-bin
     - libxkbcommon-x11-0
     - qt6-qpa-plugins
-#    - libqt6webenginecore6
-#    - libxkbcommon0
-#    - libxcb-cursor0
-#    - qt6-webengine-dev
-#    - libgl1-mesa-dev
-#    - libxkbcommon-dev
-#    - libvulkan-dev
-#    - qt6-webengine-dev-tools
   files:
     include: []
     exclude:

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,5 +1,7 @@
 # appimage-builder recipe see https://appimage-builder.readthedocs.io for details
 version: 1
+script:
+  - which mksquashfs || apt install squashfs-tools
 AppDir:
   path: ./AppDir
   app_info:

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,7 +1,7 @@
 # appimage-builder recipe see https://appimage-builder.readthedocs.io for details
 version: 1
 AppDir:
-  path: /home/agriffit/git/melodeon/build/AppDir
+  path: ./AppDir
   app_info:
     id: io.github.cdrummond.melodeon
     name: Melodeon

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,0 +1,52 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+AppDir:
+  path: /home/agriffit/git/melodeon/build/AppDir
+  app_info:
+    id: io.github.cdrummond.melodeon
+    name: Melodeon
+    icon: melodeon
+    version: 0.4.5
+    exec: usr/bin/melodeon
+    exec_args: $@
+  apt:
+    arch:
+    - amd64
+    allow_unauthenticated: true
+    sources:
+    - sourceline: deb http://gb.archive.ubuntu.com/ubuntu/ jammy main restricted
+    - sourceline: deb http://gb.archive.ubuntu.com/ubuntu/ jammy-updates main restricted
+    - sourceline: deb http://gb.archive.ubuntu.com/ubuntu/ jammy universe
+    - sourceline: deb http://gb.archive.ubuntu.com/ubuntu/ jammy-updates universe
+    - sourceline: deb http://gb.archive.ubuntu.com/ubuntu/ jammy multiverse
+    - sourceline: deb http://gb.archive.ubuntu.com/ubuntu/ jammy-updates multiverse
+    - sourceline: deb http://gb.archive.ubuntu.com/ubuntu/ jammy-backports main restricted
+        universe multiverse
+    - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security main restricted
+    - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security universe
+    - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security multiverse
+    include:
+    - libc6:amd64
+#    - libqt6webenginecore6-bin
+#    - libqt6webenginewidgets6
+#    - libqt6webenginecore6
+#    - libxkbcommon0
+#    - libxcb-cursor0
+#    - qt6-base-dev
+#    - qt6-webengine-dev
+#    - libgl1-mesa-dev
+#    - libxkbcommon-dev
+#    - libqt6svg6-dev ##
+#    - libvulkan-dev
+#    - qt6-webengine-dev-tools
+  files:
+    include: []
+    exclude:
+    - usr/share/man
+    - usr/share/doc/*/README.*
+    - usr/share/doc/*/changelog.*
+    - usr/share/doc/*/NEWS.*
+    - usr/share/doc/*/TODO.*
+AppImage:
+  arch: x86_64
+  update-information: guess

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -31,6 +31,7 @@ AppDir:
     - libc6:amd64
     - libqt6svg6
     - libqt6webenginewidgets6
+    - xkb-data
 #    - libqt6webenginecore6-bin
 #    - libqt6webenginecore6
 #    - libxkbcommon0

--- a/AppImageBuilder.yml.in
+++ b/AppImageBuilder.yml.in
@@ -8,7 +8,7 @@ AppDir:
     id: io.github.cdrummond.melodeon
     name: Melodeon
     icon: melodeon
-    version: 0.4.6
+    version: @@VERSION@@
     exec: usr/bin/melodeon
     exec_args: $@
   apt:


### PR DESCRIPTION
- Github action to build an AppImage on pushes and merges to master branch.
- The AppImage is wrapped inside a zip file and is a downloadable artifact in the Actions tab.
- Only x86_64 binary is possible as the appimage action does not have a supporting arm64 docker image.
- The version number is auto populated by extracting the most recent entry from the metainfo file.