### PR TITLE
Updates for 0.4.6 release

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -29,7 +29,7 @@ Create Snap package
 -------------------
 
 These steps assume you do not have Docker installed as it may conflict with lxd which is used by snapcraft.
-Also, enure you have plenty of spare disk space, the build process can easily consume 10-20G under /var.
+Also, ensure you have plenty of spare disk space, the build process can easily consume 10-20G under /var.
 
 1. Perform cloning steps 1-3.
 2. `sudo snap install snapcraft --classic`

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 0.4.6
 -----
 1. Remove Qt5 support.
+2. Change D-Bus name for Flathub compliance.
 
 0.4.5
 -----

--- a/linux/melodeon.metainfo.xml
+++ b/linux/melodeon.metainfo.xml
@@ -36,6 +36,15 @@
   <launchable type="desktop-id">melodeon.desktop</launchable>
 
   <releases>
+    <release version="0.4.6" date="2025-11-23">
+      <url type="details">https://github.com/CDrummond/melodeon/releases/tag/0.4.6</url>
+      <description>
+        <ul>
+          <li>Remove Qt5 supoport.</li>
+          <li>Change D-Bus name for flathub compliance.</li>
+        </ul>
+     </description>
+    </release>
     <release version="0.4.5" date="2025-05-30">
       <url type="details">https://github.com/CDrummond/melodeon/releases/tag/0.4.5</url>
       <description>


### PR DESCRIPTION
Can you please cut a new release, 0.4.6, that incorporates https://github.com/CDrummond/melodeon/pull/10. This should be the final piece that enables the flathub submission to be approved.